### PR TITLE
Fixed theme paths for newer versions of Hugo

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,4 @@
-{{ template "theme/partials/header.html" . }}
+{{ template "partials/header.html" . }}
   <div id="article">
       <h1>{{.Title}}</h1>
   <ul class="posts">
@@ -6,4 +6,4 @@
       <li><span><a href="{{ .RelPermalink }}">{{ .Title }}</a><time class="pull-right post-list">{{ .Date.Format "Mon, Jan 2, 2006" }}</h4></time></span></span></li>
       {{ end }}
   </ul>
-{{ template "theme/partials/footer.html" . }}
+{{ template "partials/footer.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,4 @@
-{{ template "theme/partials/header.html" . }}
+{{ template "partials/header.html" . }}
   <div id="article">
    <div class="article-title">{{ .Title }}</div>
    <p class="meta"><small>&nbsp;<i class="fa fa-calendar-o"></i> {{ .Date.Format  "2006-01-02" }}</small></p> <hr/>
@@ -20,4 +20,4 @@
 
     </ul>
     </div>
-{{ template "theme/partials/footer.html" . }}
+{{ template "partials/footer.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,7 +24,7 @@
 		</div>
 	</div>
 	{{ else }}
-		{{ template "theme/partials/header.html" . }}
+		{{ template "partials/header.html" . }}
   <div id="article">
       <h1>{{.Title}}</h1>
   <ul class="posts">
@@ -32,7 +32,7 @@
       <li><span><a href="{{ .RelPermalink }}">{{ .Title }}</a><time class="pull-right post-list">{{ .Date.Format "Mon, Jan 2, 2006" }}</h4></time></span></span></li>
       {{ end }}
   </ul>
-	{{ template "theme/partials/footer.html" }}	
+	{{ template "partials/footer.html" }}
 	{{ end }}
 
 	</body>


### PR DESCRIPTION
I was seeing these errors:
```
Building sites … ERROR 2018/11/28 20:58:30 render of "page" failed: "/me/dev/repo/hugo-test/themes/herring-cove
/layouts/_default/single.html:1:12": execute of template failed: html/template:_default/single.html:1:12: no such template "theme/partials/header.html"
```

I found a similar PR on another theme and implemented that fix for this template.
https://github.com/ribice/kiss/pull/39